### PR TITLE
Adds Tests For The Hooks And Fixes A Bug in Issues #37 & #38

### DIFF
--- a/tests/test_wagtail_hooks.py
+++ b/tests/test_wagtail_hooks.py
@@ -5,6 +5,7 @@ from wagtail.documents import get_document_model
 from wagtail.models import Page
 
 from tests.testapp.models import QRCodePage
+from wagtail_qrcode.models import QRCodeMixin
 from wagtail_qrcode.wagtail_hooks import (
     delete_document,
     generate_qr_code,
@@ -39,6 +40,21 @@ class TestWagtailHooks(TestCase):
         rev = test_page.save_revision()
         rev.publish()
 
+    def test_send_qr_code_email(self):
+        request = RequestFactory().get("/")
+        page = QRCodePage(title="Test Page")
+
+        root_page = Page.objects.get(id=1)
+        home_page = root_page.get_children().first()
+        home_page.add_child(instance=page)
+
+        rev = page.save_revision()
+        rev.publish()
+
+        test_page = QRCodePage.objects.get(id=page.id)
+
+        generate_qr_code(request, test_page)
+
         send_qr_code_email(
             test_page,
             email="foo@bar.com",
@@ -55,5 +71,68 @@ class TestWagtailHooks(TestCase):
             mail.outbox[0].attachments[0][0], "qr-code-{}.eps".format(test_page.id)
         )
 
+    def test_is_qrcode_instance(self):
+        # not inherit from QRCodeMixin
+        page = Page(title="Test Page")
+
+        home_page = Page.objects.get(id=1)
+        home_page.add_child(instance=page)
+
+        rev = page.save_revision()
+        rev.publish()
+
+        test_page = Page.objects.get(id=page.id)
+
+        self.assertNotIsInstance(test_page, QRCodeMixin)
+
+        # inherit from QRCodeMixin
+        qr_code_page = QRCodePage(title="Test Page")
+
+        home_page.add_child(instance=qr_code_page)
+
+        rev = qr_code_page.save_revision()
+        rev.publish()
+
+        test_qr_code_page = QRCodePage.objects.get(id=qr_code_page.id)
+
+        self.assertIsInstance(test_qr_code_page, QRCodeMixin)
+
+    def test_delete_document(self):
+        request = RequestFactory().get("/")
+        page = QRCodePage(title="Test Page")
+
+        root_page = Page.objects.get(id=1)
+        home_page = root_page.get_children().first()
+        home_page.add_child(instance=page)
+
+        rev = page.save_revision()
+        rev.publish()
+
+        test_page = QRCodePage.objects.get(id=page.id)
+
+        generate_qr_code(request, test_page)
+
+        self.assertEqual(test_page.qr_code_eps.id, 1)
+
         delete_document(request, test_page)
+
         self.assertEqual(get_document_model().objects.count(), 0)
+
+    def test_delete_document_not_qrcode_page(self):
+        request = RequestFactory().get("/")
+        page = Page(title="Test Page")
+
+        root_page = Page.objects.get(id=1)
+        home_page = root_page.get_children().first()
+        home_page.add_child(instance=page)
+
+        rev = page.save_revision()
+        rev.publish()
+
+        test_page = Page.objects.get(id=page.id)
+
+        result = delete_document(request, test_page)
+
+        # really should be None as the page does not inherit from QRCodeMixin
+        # and the function doesn't return anything
+        self.assertEqual(result, None)

--- a/tests/test_wagtail_hooks.py
+++ b/tests/test_wagtail_hooks.py
@@ -33,12 +33,12 @@ class TestWagtailHooks(TestCase):
 
         generate_qr_code(request, test_page)
 
+        rev = test_page.save_revision()
+        rev.publish()
+
         self.assertEqual(test_page.qr_code_svg[:4], "<svg")
         self.assertEqual(test_page.qr_code_eps.id, 1)
         self.assertEqual(test_page.qr_code_usage, 0)
-
-        rev = test_page.save_revision()
-        rev.publish()
 
     def test_send_qr_code_email(self):
         request = RequestFactory().get("/")

--- a/wagtail_qrcode/wagtail_hooks.py
+++ b/wagtail_qrcode/wagtail_hooks.py
@@ -24,7 +24,9 @@ def generate_qr_code(request, page):
         page.qr_code_eps = document
 
         rev = page.save_revision()
-        rev.publish()
+
+        if page.live:
+            rev.publish()
 
 
 def send_qr_code_email(page, email=None, subject=None, body=None):

--- a/wagtail_qrcode/wagtail_hooks.py
+++ b/wagtail_qrcode/wagtail_hooks.py
@@ -4,6 +4,7 @@ from wagtail import hooks
 from wagtail.documents import get_document_model
 
 from wagtail_qrcode.cls import WagtailQrCode, create_collection
+from wagtail_qrcode.models import QRCodeMixin
 
 
 @hooks.register("after_create_page")
@@ -11,12 +12,8 @@ from wagtail_qrcode.cls import WagtailQrCode, create_collection
 def generate_qr_code(request, page):
     """Add a QR code to the page."""
 
-    # dont try to generate a qrcode if the page doesn't have all these fields
-    if (
-        hasattr(page, "qr_code_svg")
-        and hasattr(page, "qr_code_eps")
-        and hasattr(page, "qr_code_usage")
-    ):
+    # dont try to generate a qrcode if the page does not inherit from QRCodeMixin
+    if is_qrcode_instance(page):
         collection = create_collection("QR Codes")
 
         qrc = WagtailQrCode(page, collection)
@@ -56,6 +53,12 @@ def send_qr_code_email(page, email=None, subject=None, body=None):
 
 @hooks.register("after_delete_page")
 def delete_document(request, page):
-    doc = get_document_model().objects.filter(id=page.qr_code_eps.id)
-    if doc:
-        doc.delete()
+    if is_qrcode_instance(page):
+        doc = get_document_model().objects.filter(id=page.qr_code_eps.id)
+        if doc:
+            doc.delete()
+
+
+def is_qrcode_instance(page):
+    """Check if the page is a QR code page and inherits from the QRCodeMixin"""
+    return isinstance(page, QRCodeMixin)


### PR DESCRIPTION
The delete_document hook would try to delete a document even if the page did not inherit from QRCodeMixin.

Hooks now check the page been operated on is an instance of QRCodeMixin before trying to generate a QR code or delete a document.

The changes here should now fix the mentioned issues.

- #38 
- #37 